### PR TITLE
shift index + 1 in oscmix.c in newoutputstereo struct

### DIFF
--- a/oscmix.c
+++ b/oscmix.c
@@ -404,9 +404,9 @@ newoutputstereo(struct context *ctx, int val)
 	out = &outputs[ctx->param.out & ~1];
 	out[0].stereo = val;
 	out[1].stereo = val;
-	snprintf(ctx->addr, ctx->addrend - ctx->addr, "/output/%d/stereo", (int)(out - outputs));
-	oscsend(ctx->addr, ",i", val != 0);
 	snprintf(ctx->addr, ctx->addrend - ctx->addr, "/output/%d/stereo", (int)(out - outputs + 1));
+	oscsend(ctx->addr, ",i", val != 0);
+	snprintf(ctx->addr, ctx->addrend - ctx->addr, "/output/%d/stereo", (int)(out - outputs + 2));
 	oscsend(ctx->addr, ",i", val != 0);
 }
 


### PR DESCRIPTION
- The stereo checkbox in webui showed this messages when dis-/en-abling stereo in output channels, while the input channels behave correctly.  Here for first AN1 Out: 
oscmix.js /output/1/stereo ,i [false]
oscmix.js /output/0/stereo [0]
oscmix.js /output/1/stereo  [0]
- So, the UI never updated its output channels correctly as the index seems to be incorrect(0 instead of 1, 1 instead of 2, etc...)
- Checked the .js files: - OK
- Checked device_*.c - OK
- The index is fixed now by modifying the 2 lines in oscmix.c